### PR TITLE
Use develop version of upload image

### DIFF
--- a/.github/workflows/generate_mongrel.yml
+++ b/.github/workflows/generate_mongrel.yml
@@ -35,7 +35,7 @@ jobs:
         if-no-files-found: error
     - name: Upload image
       id: upload_image
-      uses: McCzarny/upload-image@v1.3.0
+      uses: McCzarny/upload-image@develop
       if: github.event_name == 'pull_request'
       with:
         path: |


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates the GitHub Actions workflow to use the development version of the upload-image action instead of the stable v1.3.0 release.

- Changed the reference to `McCzarny/upload-image` action from `v1.3.0` to `develop` branch in the workflow file, potentially to use newer features or fixes that aren't yet in a stable release.
- This change affects the step that uploads generated mongrel images to imgbb when a pull request is created.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->